### PR TITLE
fix dependency sources

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "^18.6.2",
         "bignumber.js": "^9.0.2",
         "chai": "^4.3.6",
-        "ever-wever": "git+ssh://git@gitlab.broxus.com/tokens/ever-wever#e19da2e77de349e493a9daf86710c3a2256d20d1",
+        "ever-wever": "github:broxus/ever-wever#e19da2e77de349e493a9daf86710c3a2256d20d1",
         "everscale-standalone-client": "2.1.23",
         "ipfs-core": "^0.14.2",
         "locklift": "2.8.1",
@@ -30,7 +30,7 @@
         "ora": "^3.4.0",
         "prettier": "^2.7.1",
         "prompts": "^2.4.1",
-        "tip3": "git://github.com/broxus/tip3#83e69b99e287bc551672f9df170e39c25b93876d",
+        "tip3": "github:broxus/tip3#83e69b99e287bc551672f9df170e39c25b93876d",
         "ts-mocha": "^10.0.0",
         "ts-node": "^10.7.0",
         "typescript": "^4.7.4"
@@ -2641,9 +2641,9 @@
     "node_modules/ever-wever": {
       "name": "wton",
       "version": "1.0.0",
-      "resolved": "git+ssh://git@gitlab.broxus.com/tokens/ever-wever#e19da2e77de349e493a9daf86710c3a2256d20d1",
+      "resolved": "git+ssh://git@github.com/broxus/ever-wever.git#e19da2e77de349e493a9daf86710c3a2256d20d1",
+      "integrity": "sha512-0YYka4yWmzrXeLGXJQOSxL6wLmIBt1HjCJvjgWxqBD9N6t05n3V47sOpjtkWfpk0F1+bm6p/SdfTEAPcU5QBYQ==",
       "dev": true,
-      "license": "GNU AGPLv3",
       "dependencies": {
         "@broxus/contracts": "^1.1.1",
         "@broxus/locklift-deploy": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "ora": "^3.4.0",
     "prettier": "^2.7.1",
     "prompts": "^2.4.1",
-    "tip3": "git://github.com/broxus/tip3#83e69b99e287bc551672f9df170e39c25b93876d",
-    "ever-wever": "git+ssh://git@gitlab.broxus.com/tokens/ever-wever#e19da2e77de349e493a9daf86710c3a2256d20d1",
+    "tip3": "github:broxus/tip3#83e69b99e287bc551672f9df170e39c25b93876d",
+    "ever-wever": "github:broxus/ever-wever#e19da2e77de349e493a9daf86710c3a2256d20d1",
     "ts-mocha": "^10.0.0",
     "ts-node": "^10.7.0",
     "typescript": "^4.7.4"


### PR DESCRIPTION
This change fixes the error that the user will receive when trying to install project dependencies, the problem is that some dependencies use a private repository. 

Attempt number one https://github.com/blockchain-family/nft-marketplace-contracts/pull/3

JFIY please don't force the main thread